### PR TITLE
Stop posting duplicate tweets

### DIFF
--- a/.github/workflows/tweet-current-age-criteria.yml
+++ b/.github/workflows/tweet-current-age-criteria.yml
@@ -23,7 +23,7 @@ jobs:
       run: echo ::set-output name=age::$(bundle exec ruby script/get_current_age_criteria.rb)
     - name: Output age criteria
       run: echo ${{ steps.criteria.outputs.age }}
-    - name: Should i text it?
+    - name: Should i post a notification?
       id: should-i-send
       run: |
         if [[ '${{ steps.criteria.outputs.age }}' =~ ${{ secrets.SMS_REGEX }} ]]; then
@@ -42,6 +42,7 @@ jobs:
         TWILIO_API_SECRET: ${{ secrets.TWILIO_API_SECRET }}
     - name: Tweet current age criteria
       uses: devigned/go-twitter-action@v1
+      if: steps.should-i-send.outputs.match == 'true'
       with:
         message: ${{ steps.criteria.outputs.age }}
         apiKey: ${{ secrets.API_KEY }}


### PR DESCRIPTION
Currently this bot does not know if criteria has changed or not. So it
always posts the age criteria to twitter, and lets twitter reject
duplicates.

But twitter allows a duplicate tweet after ~12 hours. So every 12 hours
the bot repeats itself.

For now lets copy the regex the SMS notifications use to prevent
duplicates being sent.