### PR TITLE
Cache gems on github actions

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -12,15 +12,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
-    - name: Cache gems
-      uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-rubocop-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-rubocop-
-    - name: Install gems
-      run: |
-        bundle install --jobs 4 --retry 3 --verbose
+        bundler-cache: true
     - name: Run RuboCop
       run: bundle exec rubocop --parallel

--- a/.github/workflows/tweet-current-age-criteria.yml
+++ b/.github/workflows/tweet-current-age-criteria.yml
@@ -15,9 +15,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
-    - name: Install gems
-      run: |
-        bundle install --jobs 4 --retry 3
+        bundler-cache: true
     - shell: bash
       name: Get current age criteria
       id: criteria

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,7 @@ AllCops:
   Exclude:
     - 'script/scratch.rb'
     - 'Gemfile'
+    - vendor/bundle/**/*
 
 Style/Documentation:
   Enabled: false


### PR DESCRIPTION
About half of the execution time on github actions was being spent
installing gems.

Turns out the ruby/setup-ruby action comes with bundler caching support
out of the box, so I have enabled it.

This reduced bundle install time from ~25 seconds to almost zero!

We've also had to tell Rubocop to ignore the gem cache, because it would
otherwise try to lint all the gems and load their own rubocop
configs.[1]

[1] https://github.com/rubocop/rubocop/issues/6398