### PR TITLE
Update age regex

### DIFF
--- a/.github/workflows/tweet-current-age-criteria.yml
+++ b/.github/workflows/tweet-current-age-criteria.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Should i post a notification?
       id: should-i-send
       run: |
-        if [[ '${{ steps.criteria.outputs.age }}' =~ [(0-3|6-9)]+ ]] && [[ '${{ secrets.TWEETING_ENABLED }}' == 'enabled' ]]; then
+        if [[ ! '${{ steps.criteria.outputs.age }}' =~ 'aged 45' ]] && [[ '${{ secrets.TWEETING_ENABLED }}' == 'enabled' ]]; then
             echo ::set-output name=match::true
         fi
     - name: 'Send SMS Notification'


### PR DESCRIPTION
The way the age criteria is phrased has changed. It now is something
like:

'you were aged 45 or over on or before 30 March 2021'

Now that sentence contains digits that aren't related to the age limit.
This makes the old regex ineffective, so I'm switching to a new
approach.